### PR TITLE
fix(legacy): prevent power_shop_meta wipe and lock down ajax endpoint

### DIFF
--- a/legacy/inc/classes/Ajax.php
+++ b/legacy/inc/classes/Ajax.php
@@ -18,12 +18,32 @@ final class Ajax {
 
 	/**
 	 * Constructor
+	 *
+	 * Endpoints read/write Power Shop post meta. Both require an authenticated
+	 * editor session, so we deliberately do NOT register `wp_ajax_nopriv_*`
+	 * counterparts. Allowing anonymous access here was the historical cause of
+	 * `power_shop_meta` being wiped to `[]` by random POSTs from bots.
 	 */
 	public function __construct() {
 		foreach ( [ self::GET_POST_META_ACTION, self::UPDATE_POST_META_ACTION ] as $action) {
 			\add_action('wp_ajax_' . $action, [ $this, $action . '_callback' ]);
-			\add_action('wp_ajax_nopriv_' . $action, [ $this, $action . '_callback' ]);
 		}
+	}
+
+	/**
+	 * Meta keys this endpoint is allowed to read or write.
+	 *
+	 * Without an allowlist a caller could pull/push arbitrary post meta via
+	 * this generic endpoint, leaking private keys (e.g. `_edit_lock`) or
+	 * stomping on unrelated meta.
+	 *
+	 * @return string[]
+	 */
+	private function allowed_meta_keys(): array {
+		return [
+			Plugin::$snake . '_meta',
+			Plugin::$snake . '_settings',
+		];
 	}
 
 	/**
@@ -32,58 +52,123 @@ final class Ajax {
 	 * @return void
 	 */
 	public function ps_handle_get_post_meta_callback() {
-		// Security check
-		// \check_ajax_referer(Plugin::$kebab, 'nonce');
-		$post_id  = \sanitize_text_field( wp_unslash( $_POST['post_id'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$meta_key = \sanitize_text_field( wp_unslash( $_POST['meta_key'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$post_id  = \absint( \wp_unslash( $_POST['post_id'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$meta_key = \sanitize_text_field( \wp_unslash( $_POST['meta_key'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
-		if (empty($post_id)) {
+		if ( empty( $post_id ) ) {
+			\wp_send_json( [ 'message' => 'error', 'data' => [ 'reason' => 'missing post_id' ] ] );
 			return;
 		}
 
-		$post_id   = $post_id;
-		$post_meta = empty($meta_key) ? \get_post_meta($post_id) : \get_post_meta($post_id, $meta_key, true);
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			\wp_send_json( [ 'message' => 'error', 'data' => [ 'reason' => 'permission denied' ] ] );
+			return;
+		}
 
-		$return = [
-			'message' => 'success',
-			'data'    => [
-				'post_meta' => $post_meta,
-			],
-		];
+		// When a meta_key is supplied it must be one we explicitly own.
+		if ( ! empty( $meta_key ) && ! \in_array( $meta_key, $this->allowed_meta_keys(), true ) ) {
+			\wp_send_json( [ 'message' => 'error', 'data' => [ 'reason' => 'meta_key not allowed: ' . $meta_key ] ] );
+			return;
+		}
 
-		\wp_send_json($return);
+		$post_meta = empty( $meta_key ) ? \get_post_meta( $post_id ) : \get_post_meta( $post_id, $meta_key, true );
 
-		\wp_die();
+		\wp_send_json(
+			[
+				'message' => 'success',
+				'data'    => [
+					'post_meta' => $post_meta,
+				],
+			]
+		);
 	}
 
 	/**
 	 * Handle update post meta callback
 	 *
+	 * Defenses, in order:
+	 *  1. Login + capability check (nopriv removed in __construct).
+	 *  2. Meta-key allowlist — only Power Shop's own meta may be written.
+	 *  3. JSON value passes through unsanitised: `sanitize_text_field` on a
+	 *     JSON blob silently mangles whitespace and `<` characters.
+	 *  4. Anti-wipe guard: refuse to overwrite a non-empty product list with
+	 *     an empty one. Pass `force=1` to override (e.g. real "clear all").
+	 *  5. History snapshot: every successful overwrite of a non-empty list
+	 *     stashes the previous value into `power_shop_meta_history` so we
+	 *     can recover from accidents (last 5 retained).
+	 *
 	 * @return void
 	 */
 	public function handle_update_post_meta_callback() {
-		// Security check
-		// \check_ajax_referer(Plugin::$kebab, 'nonce');
-		$post_id    = \sanitize_text_field( wp_unslash( $_POST['post_id'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$meta_key   = \sanitize_text_field( wp_unslash( $_POST['meta_key'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$meta_value = \sanitize_text_field( wp_unslash( $_POST['meta_value'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$post_id    = \absint( \wp_unslash( $_POST['post_id'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$meta_key   = \sanitize_text_field( \wp_unslash( $_POST['meta_key'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$meta_value = \wp_unslash( $_POST['meta_value'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- JSON string; sanitize_text_field would mangle it.
 
-		if (empty($post_id) || empty($meta_key)) {
+		if ( empty( $post_id ) || empty( $meta_key ) ) {
+			\wp_send_json( [ 'message' => 'error', 'data' => [ 'reason' => 'missing post_id or meta_key' ] ] );
 			return;
 		}
 
-		$post_id       = $post_id;
-		$update_result = \update_post_meta($post_id, $meta_key, $meta_value);
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			\wp_send_json( [ 'message' => 'error', 'data' => [ 'reason' => 'permission denied' ] ] );
+			return;
+		}
 
-		$return = [
-			'message' => 'success',
-			'data'    => [
-				'update_result' => $update_result,
-			],
-		];
+		if ( ! \in_array( $meta_key, $this->allowed_meta_keys(), true ) ) {
+			\wp_send_json( [ 'message' => 'error', 'data' => [ 'reason' => 'meta_key not allowed: ' . $meta_key ] ] );
+			return;
+		}
 
-		\wp_send_json($return);
+		$products_meta_key = Plugin::$snake . '_meta';
+		if ( $products_meta_key === $meta_key ) {
+			$previous_raw = (string) \get_post_meta( $post_id, $meta_key, true );
+			$previous     = \json_decode( $previous_raw, true );
+			$new          = \json_decode( (string) $meta_value, true );
 
-		\wp_die();
+			$prev_count = \is_array( $previous ) ? \count( $previous ) : 0;
+			$new_count  = \is_array( $new ) ? \count( $new ) : 0;
+
+			$force = ! empty( $_POST['force'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+			if ( $prev_count > 0 && 0 === $new_count && ! $force ) {
+				\wp_send_json(
+					[
+						'message' => 'refused',
+						'data'    => [
+							'reason'         => sprintf(
+								'Refused to overwrite %d products with an empty list. Resend with force=1 to override.',
+								$prev_count
+							),
+							'previous_count' => $prev_count,
+						],
+					]
+				);
+				return;
+			}
+
+			if ( $prev_count > 0 ) {
+				$history_key = Plugin::$snake . '_meta_history';
+				$history     = \get_post_meta( $post_id, $history_key, true );
+				$history     = \is_array( $history ) ? $history : [];
+				$history[]   = [
+					'saved_at' => \current_time( 'mysql' ),
+					'user_id'  => \get_current_user_id(),
+					'value'    => $previous_raw,
+				];
+				$history     = \array_slice( $history, -5 );
+				\update_post_meta( $post_id, $history_key, $history );
+			}
+		}
+
+		$update_result = \update_post_meta( $post_id, $meta_key, $meta_value );
+
+		\wp_send_json(
+			[
+				'message' => 'success',
+				'data'    => [
+					'update_result' => $update_result,
+				],
+			]
+		);
 	}
 }


### PR DESCRIPTION
## Context — real-world incident

A customer site (`drwine1984.com`) reported a Power Shop campaign page (`/power-shop/moscato-2026-summer/`) rendering an empty product grid. Investigation showed `power_shop_meta` on that post had been silently overwritten with `[]` — the products list was gone. WP revisions don't carry post meta and the site has no other backup, so the data was unrecoverable.

The same kind of report has come up before (the customer's wording was 「**又**抓不到全部商品」 — *again* can't grab all products), so this is a recurring class of incident, not a one-off.

## Root cause

`legacy/inc/classes/Ajax.php::handle_update_post_meta_callback()` had five stacked weaknesses, any of which alone makes silent data loss possible:

1. **`wp_ajax_nopriv_*` registered** → unauthenticated POSTs to `admin-ajax.php` could read or write meta.
2. **No capability check** → any logged-in user (subscriber, customer) could overwrite shop meta.
3. **No meta-key allowlist** → the generic endpoint accepted any `meta_key`, enabling reads of private meta (`_edit_lock` etc.) or writes that stomp on unrelated data.
4. **`sanitize_text_field` on a JSON blob** → silently mangles whitespace and `<` characters; a large product payload can become unparseable JSON, which downstream `json_decode → is_array` fallback turns into `[]`.
5. **No degradation guard** → a request with `meta_value=[]` overwrites a non-empty list with no warning, no confirmation, no backup.

## What this PR changes

`legacy/inc/classes/Ajax.php`:

- Drop `wp_ajax_nopriv_*` registration. Both endpoints require an authenticated session.
- Add `current_user_can('edit_post', $post_id)` to both handlers.
- Restrict `meta_key` to a small allowlist (`power_shop_meta`, `power_shop_settings`).
- Stop running `sanitize_text_field` on the JSON `meta_value`.
- **Anti-wipe guard**: refuse to overwrite a non-empty product list with an empty one. Pass `force=1` to override (legitimate "clear all").
- **History snapshot**: each overwrite of a non-empty list stashes the previous JSON into `power_shop_meta_history` (last 5 retained), so future accidents are recoverable in one `wp-cli` call:
  ```bash
  wp eval '$h = get_post_meta(POST_ID, "power_shop_meta_history", true); update_post_meta(POST_ID, "power_shop_meta", end($h)["value"]);'
  ```
- Use `absint` for `post_id` and surface explicit error responses (`message: 'error' | 'refused'`) instead of silently `return`-ing.

Existing success-response shape (`{message: 'success', data: {update_result}}`) is preserved so the React UI keeps working unchanged.

## Verification

Smoke-tested on `drwine1984.com` against the actual production install (PHP 8.1.34, WP current). Original `Ajax.php` was backed up to `Ajax.php.bak.20260504_071403` on disk before swap; opcache reset; site stayed at HTTP 200 throughout.

| # | Scenario | Result |
|---|---|---|
| 1  | Anonymous POST → update endpoint | ✓ HTTP 400 + `0` (handler not registered) |
| 1b | Anonymous POST → get endpoint    | ✓ HTTP 400 + `0` |
| 2  | Admin: overwrite 3 products with `[]`, no force | ✓ `message: 'refused'`, meta unchanged |
| 3  | Admin: same with `force=1` | ✓ `message: 'success'`, meta cleared, `power_shop_meta_history` has the previous value |
| 4  | Admin: try to write `_edit_lock` via this endpoint | ✓ blocked by allowlist, `_edit_lock` unchanged |
| 5  | Admin: legitimate non-empty save | ✓ saved as expected |
| 6  | Subscriber: try to wipe with `force=1` | ✓ `permission denied`, meta unchanged |

All 7 green. The smoke-test driver (`/tmp/ps-smoke.php`) creates a throwaway `power-shop` draft and a temporary subscriber, then deletes both.

## Possible follow-ups (intentionally out of scope here)

- A `wp power-shop restore <post_id>` wp-cli subcommand that reads `power_shop_meta_history` and writes back the latest snapshot. The one-liner above already works; this is just convenience.
- Frontend (React) handling of the new `refused` response so editors see a clear error instead of an apparent silent success. The legacy JS source is not in this repo.
- Same nonce + cap-check treatment for any other ad-hoc admin-ajax endpoints that show the same `nopriv` + commented-out `check_ajax_referer` shape.

## Customer impact

`drwine1984.com` post 55495's `power_shop_meta` is still `[]` — this PR does not fix that data, only stops it from happening again. The customer is being asked to re-supply the product list, which we'll re-seed via wp-cli.